### PR TITLE
Fix DAGs's environment variables

### DIFF
--- a/dags/utils/helpers.py
+++ b/dags/utils/helpers.py
@@ -47,7 +47,8 @@ def _create_task(task_id, dag, image, command, environment):
         'PYTHON_ENV': airflow.models.Variable.get('ENV'),
         'LOGGING_URL': airflow.models.Variable.get('LOGGING_URL'),
         'DOWNLOAD_DELAY': airflow.models.Variable.get('DOWNLOAD_DELAY'),
-    }.update(environment)
+    }
+    env.update(environment)
     docker_api_version = os.environ.get('DOCKER_API_VERSION', '1.23')
 
     return DockerOperator(

--- a/tests/dags/utils/test_helpers.py
+++ b/tests/dags/utils/test_helpers.py
@@ -29,6 +29,15 @@ class TestGetPostgresUriHelper(object):
 
 
 class TestCreateTasks(object):
+    DEFAULT_ENV_KEYS = [
+        'WAREHOUSE_URL',
+        'DATABASE_URL',
+        'EXPLORERDB_URL',
+        'PYTHON_ENV',
+        'LOGGING_URL',
+        'DOWNLOAD_DELAY',
+    ]
+
     def test_create_collector_task_returns_tasks_with_correct_options(self):
         dag = None
         with mock.patch('airflow.hooks.BaseHook'), mock.patch('airflow.models.Variable'):
@@ -37,6 +46,7 @@ class TestCreateTasks(object):
         assert task.task_id == 'collector_foo'
         assert task.image == 'okibot/collectors:latest'
         assert task.force_pull
+        assert sorted(task.environment.keys()) == sorted(self.DEFAULT_ENV_KEYS)
 
     def test_create_processor_task_returns_tasks_with_correct_options(self):
         dag = None
@@ -46,3 +56,4 @@ class TestCreateTasks(object):
         assert task.task_id == 'processor_foo'
         assert task.image == 'okibot/processors:latest'
         assert task.force_pull
+        assert sorted(task.environment.keys()) == sorted(self.DEFAULT_ENV_KEYS)


### PR DESCRIPTION
The dict's method `.update()` returns `None`, not the updated dict. So, as we're
calling this, we're always getting `env == None`, and so the containers were
running with an empty environment. This commit fixes it and adds a test to make
sure it doesn't happen again.