### PR TITLE
Allow specifying the command in processors/collectors tasks

### DIFF
--- a/dags/actrn.py
+++ b/dags/actrn.py
@@ -18,7 +18,8 @@ dag = DAG(
 
 collector_task = helpers.create_collector_task(
     name='actrn',
-    dag=dag
+    dag=dag,
+    command='make start actrn 2001-01-01'
 )
 
 processor_task = helpers.create_processor_task(

--- a/dags/euctr.py
+++ b/dags/euctr.py
@@ -18,7 +18,8 @@ dag = DAG(
 
 collector_task = helpers.create_collector_task(
     name='euctr',
-    dag=dag
+    dag=dag,
+    command='make start euctr 2001-01-01'
 )
 
 processor_task = helpers.create_processor_task(

--- a/dags/gsk.py
+++ b/dags/gsk.py
@@ -18,7 +18,8 @@ dag = DAG(
 
 collector_task = helpers.create_collector_task(
     name='gsk',
-    dag=dag
+    dag=dag,
+    command='make start gsk 2001-01-01'
 )
 
 processor_task = helpers.create_processor_task(

--- a/dags/isrctn.py
+++ b/dags/isrctn.py
@@ -17,12 +17,13 @@ dag = DAG(
 )
 
 collector_task = helpers.create_collector_task(
-    name='irctn',
-    dag=dag
+    name='isrctn',
+    dag=dag,
+    command='make start isrctn 2001-01-01'
 )
 
 processor_task = helpers.create_processor_task(
-    name='irctn',
+    name='isrctn',
     dag=dag
 )
 

--- a/dags/jprn.py
+++ b/dags/jprn.py
@@ -18,7 +18,8 @@ dag = DAG(
 
 collector_task = helpers.create_collector_task(
     name='jprn',
-    dag=dag
+    dag=dag,
+    command='make start jprn 1 100000'
 )
 
 processor_task = helpers.create_processor_task(

--- a/dags/nct.py
+++ b/dags/nct.py
@@ -18,7 +18,8 @@ dag = DAG(
 
 collector_task = helpers.create_collector_task(
     name='nct',
-    dag=dag
+    dag=dag,
+    command='make start nct 2001-01-01'
 )
 
 processor_task = helpers.create_processor_task(

--- a/dags/pubmed.py
+++ b/dags/pubmed.py
@@ -17,12 +17,13 @@ dag = DAG(
 )
 
 collector_task = helpers.create_collector_task(
-    name='pubmed_collector',
-    dag=dag
+    name='pubmed',
+    dag=dag,
+    command='make start pubmed 1900-01-01 2100-01-01'
 )
 
 processor_task = helpers.create_processor_task(
-    name='pubmed_processor',
+    name='pubmed',
     dag=dag
 )
 

--- a/dags/utils/helpers.py
+++ b/dags/utils/helpers.py
@@ -19,22 +19,26 @@ def get_postgres_uri(name):
     )
 
 
-def create_collector_task(name, dag, environment=None):
+def create_collector_task(name, dag, command=None, environment=None):
+    default_command = 'make start {}'.format(name)
+
     return _create_task(
         task_id='collector_{}'.format(name),
         dag=dag,
         image='okibot/collectors:latest',
-        command='make start {}'.format(name),
+        command=command or default_command,
         environment=environment or {},
     )
 
 
-def create_processor_task(name, dag, environment=None):
+def create_processor_task(name, dag, command=None, environment=None):
+    default_command = 'make start {}'.format(name)
+
     return _create_task(
         task_id='processor_{}'.format(name),
         dag=dag,
         image='okibot/processors:latest',
-        command='make start {}'.format(name),
+        command=command or default_command,
         environment=environment or {},
     )
 

--- a/tests/dags/utils/test_helpers.py
+++ b/tests/dags/utils/test_helpers.py
@@ -48,6 +48,14 @@ class TestCreateTasks(object):
         assert task.force_pull
         assert sorted(task.environment.keys()) == sorted(self.DEFAULT_ENV_KEYS)
 
+    def test_create_collector_task_allows_changing_command(self):
+        dag = None
+        command = 'sleep'
+        with mock.patch('airflow.hooks.BaseHook'), mock.patch('airflow.models.Variable'):
+            task = helpers.create_collector_task('foo', dag, command)
+
+        assert task.command == command
+
     def test_create_processor_task_returns_tasks_with_correct_options(self):
         dag = None
         with mock.patch('airflow.hooks.BaseHook'), mock.patch('airflow.models.Variable'):


### PR DESCRIPTION
We need to specify the command to pass parameters like the start and end dates.