### PR TITLE
Download ClinicalTrials.gov XML dump before running NCT collector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 *.retry
 *undo-tree~
 *.un~
-venv
+env
 *.swp
 .tox
 .cache

--- a/dags/nct.py
+++ b/dags/nct.py
@@ -1,12 +1,15 @@
 import datetime
+import airflow.operators.sensors
 from airflow.models import DAG
 import utils.helpers as helpers
+from operators.http_to_s3_transfer import HTTPToS3Transfer
 
 args = {
     'owner': 'airflow',
     'depends_on_past': False,
-    'start_date': datetime.datetime.utcnow(),
+    'start_date': datetime.datetime(2017, 1, 1),
     'retries': 1,
+    'retry_delay': datetime.timedelta(minutes=10),
 }
 
 dag = DAG(
@@ -16,10 +19,40 @@ dag = DAG(
     schedule_interval='@monthly'
 )
 
+HTTP_CONN_ID = 'datastore_http'
+S3_BASE_URL = airflow.hooks.BaseHook.get_connection(HTTP_CONN_ID).host
+S3_URL_ENDPOINT = '/dumps/sources/nct_2001-01-01_{{ end_date }}.zip'
+NCT_DATA_URL = '{base}{endpoint}'.format(
+    base=S3_BASE_URL,
+    endpoint=S3_URL_ENDPOINT
+)
+
+save_nct_xml_to_s3_task = HTTPToS3Transfer(
+    task_id='save_nct_xml_to_s3',
+    dag=dag,
+    url='https://clinicaltrials.gov/search',
+    url_params={
+        'resultsxml': 'True',
+        'rcv_s': '01/01/2001',
+        'rcv_e': '{{ macros.ds_format(end_date, "%Y-%m-%d", "%d/%m/%Y") }}',
+    },
+    s3_conn_id='datastore_s3',
+    s3_url=NCT_DATA_URL.replace('http://', 's3://'),
+)
+
+# FIXME: This should be a S3Sensor, but I have issues with it, so we need to
+# use HTTP for now. See https://issues.apache.org/jira/browse/AIRFLOW-115.
+nct_xml_dump_sensor = airflow.operators.sensors.HttpSensor(
+    task_id='nct_xml_dump_sensor',
+    dag=dag,
+    http_conn_id=HTTP_CONN_ID,
+    endpoint=S3_URL_ENDPOINT
+)
+
 collector_task = helpers.create_collector_task(
     name='nct',
     dag=dag,
-    command='make start nct 2001-01-01'
+    command='make start nct {url}'.format(url=NCT_DATA_URL)
 )
 
 processor_task = helpers.create_processor_task(
@@ -32,5 +65,6 @@ merge_trials_identifiers_task = helpers.create_processor_task(
     dag=dag
 )
 
+collector_task.set_upstream(nct_xml_dump_sensor)
 processor_task.set_upstream(collector_task)
 merge_trials_identifiers_task.set_upstream(processor_task)

--- a/dags/operators/http_to_s3_transfer.py
+++ b/dags/operators/http_to_s3_transfer.py
@@ -1,0 +1,94 @@
+from urllib.parse import urlparse
+import logging
+import contextlib
+import requests
+import boto3
+
+import airflow.hooks
+import airflow.exceptions
+from airflow.models import BaseOperator
+from airflow.utils.decorators import apply_defaults
+
+
+class HTTPToS3Transfer(BaseOperator):
+    '''
+    Downloads an URL's contents and stream it to S3.
+
+
+    :param url: URL to download. (templated)
+    :type url: str
+    :param s3_conn_id: S3 Connection's ID. It needs a JSON in the `extra` field
+        with `aws_access_key_id` and `aws_secret_access_key`
+    :type s3_conn_id: str
+    :param s3_url: S3 url (e.g. `s3://my_bucket/my_key.zip`) (templated)
+    :type s3_bucket: str
+    '''
+    template_fields = ('url', 'url_params', 's3_url')
+
+    @apply_defaults
+    def __init__(self, url, s3_conn_id, s3_url, url_params=None, *args, **kwargs):
+        super(HTTPToS3Transfer, self).__init__(*args, **kwargs)
+        self.url = url
+        self.url_params = url_params
+        self.s3_conn_id = s3_conn_id
+        self.s3_url = s3_url
+
+    def execute(self, context):
+        s3 = self._load_s3_connection(self.s3_conn_id)
+        s3_bucket, s3_key = self._parse_s3_url(self.s3_url)
+
+        logging.info(
+            'Streaming %s (params %s) to S3 (%s)',
+            self.url,
+            self.url_params,
+            self.s3_url,
+        )
+
+        with contextlib.closing(requests.get(self.url, params=self.url_params, stream=True)) as response:
+            s3.Bucket(s3_bucket) \
+              .upload_fileobj(response.raw, s3_key, Callback=_progress_logger())
+
+    @staticmethod
+    def _parse_s3_url(s3_url):
+        parsed_url = urlparse(s3_url)
+        if not parsed_url.netloc:
+            raise airflow.exceptions.AirflowException('Please provide a bucket_name')
+        else:
+            bucket_name = parsed_url.netloc
+            key = parsed_url.path.strip('/')
+            return (bucket_name, key)
+
+    def _load_s3_connection(self, conn_id):
+        '''
+        Parses the S3 connection and returns a Boto3 resource.
+
+        This should be implementing using the S3Hook, but it currently uses
+        boto (not boto3) which doesn't allow streaming.
+
+        :return: Boto3 resource
+        :rtype: boto3.resources.factory.s3.ServiceResource
+        '''
+        conn = airflow.hooks.BaseHook.get_connection(conn_id)
+        extra_dejson = conn.extra_dejson
+        key_id = extra_dejson['aws_access_key_id']
+        access_key = extra_dejson['aws_secret_access_key']
+
+        s3 = boto3.resource(
+            's3',
+            aws_access_key_id=key_id,
+            aws_secret_access_key=access_key
+        )
+
+        return s3
+
+
+def _progress_logger():
+    '''Closure to keep track and log the download progress.'''
+    total_bytes = 0
+
+    def log_progress(bytes_count):
+        nonlocal total_bytes
+        total_bytes += bytes_count
+        logging.debug('Downloaded %d bytes', total_bytes)
+
+    return log_progress

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ airflow[async,password,crypto]==1.7.1.3
 docker-py==1.10.4
 boto3==1.4.1
 retrying==1.3.3
+requests==2.13.0

--- a/tests/dags/operators/test_http_to_s3_transfer.py
+++ b/tests/dags/operators/test_http_to_s3_transfer.py
@@ -1,0 +1,83 @@
+import unittest.mock as mock
+import pytest
+from dags.operators.http_to_s3_transfer import HTTPToS3Transfer
+
+
+class TestHTTPToS3Transfer(object):
+    def test_its_created_successfully(self):
+        operator = HTTPToS3Transfer(
+            task_id='task_id',
+            url='http://example.com/data.zip',
+            s3_conn_id='s3_conn_id',
+            s3_url='s3://bucket/key'
+        )
+        assert operator
+
+    @mock.patch('requests.get')
+    @mock.patch('boto3.resource')
+    @mock.patch('airflow.hooks.BaseHook.get_connection')
+    def test_execute_streams_url_data_to_s3(self, get_connection_mock, boto3_mock, get_mock):
+        get_connection_mock.return_value = mock.Mock(extra_dejson={
+            'aws_access_key_id': 'AWS_ACCESS_KEY_ID',
+            'aws_secret_access_key': 'AWS_SECRET_ACCESS_KEY',
+        })
+        s3_bucket_mock = mock.Mock()
+        s3_mock = mock.Mock()
+        s3_mock.Bucket.return_value = s3_bucket_mock
+        boto3_mock.return_value = s3_mock
+
+        operator = HTTPToS3Transfer(
+            task_id='task_id',
+            url='http://example.com/data.zip',
+            s3_conn_id='s3_conn_id',
+            s3_url='s3://bucket/key'
+        )
+
+        operator.execute(None)
+
+        get_mock.assert_called_with(
+            operator.url,
+            params=operator.url_params,
+            stream=True
+        )
+
+        s3_mock.Bucket.assert_called_with('bucket')
+        s3_bucket_mock.upload_fileobj.assert_called_with(
+            get_mock.return_value.raw,
+            'key',
+            Callback=mock.ANY
+        )
+
+    @mock.patch('airflow.hooks.BaseHook.get_connection')
+    def test_execute_requires_aws_access_key_id_in_connection_extra(self, get_connection_mock):
+        get_connection_mock.return_value = mock.Mock(extra_dejson={
+            'aws_secret_access_key': 'AWS_SECRET_ACCESS_KEY',
+        })
+
+        operator = HTTPToS3Transfer(
+            task_id='task_id',
+            url='http://example.com/data.zip',
+            s3_conn_id='s3_conn_id',
+            s3_url='s3://bucket/key'
+        )
+
+        with pytest.raises(KeyError) as excinfo:
+            operator.execute(None)
+        assert 'aws_access_key_id' in str(excinfo.value)
+
+    @mock.patch('airflow.hooks.BaseHook.get_connection')
+    def test_execute_requires_aws_secret_access_key_in_connection_extra(self, get_connection_mock):
+        get_connection_mock.return_value = mock.Mock(extra_dejson={
+            'aws_access_key_id': 'AWS_ACCESS_KEY_ID',
+        })
+
+        operator = HTTPToS3Transfer(
+            task_id='task_id',
+            url='http://example.com/data.zip',
+            s3_conn_id='s3_conn_id',
+            s3_url='s3://bucket/key'
+        )
+
+        with pytest.raises(KeyError) as excinfo:
+            operator.execute(None)
+        assert 'aws_secret_access_key' in str(excinfo.value)

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,10 @@ setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/dags
     AIRFLOW_DAGS = {toxinidir}/dags
 commands =
-    pytest {posargs}
+    py.test {posargs}
+
+[pytest]
+testpaths=tests
 
 [testenv:lint]
 deps =
@@ -23,3 +26,6 @@ commands =
 [flake8]
 ignore =
   E501
+exclude =
+  env,
+  .tox


### PR DESCRIPTION
**Ignore virtualenv folder `env` when running tox**
I also added it to .gitignore

**[#679] Download ClinicalTrials.gov XML dump before running collector**
This not only allow us to re-run the data pipeline with the same input data (to
debug issues, for instance), but also keeps the history of the XML dumps we've
extracted.

This commit requires 2 new connections: `datastore_http` and `datastore_s3`.

opentrials/opentrials#679