### PR TITLE
Use Python 2.7 instead of 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 
-python: 3.5
+python: 2.7
 
 env:
     - TOXENV="py${PYTHON_VERSION//./}"

--- a/dags/operators/http_to_s3_transfer.py
+++ b/dags/operators/http_to_s3_transfer.py
@@ -87,7 +87,7 @@ def _progress_logger():
     total_bytes = 0
 
     def log_progress(bytes_count):
-        nonlocal total_bytes
+        global total_bytes
         total_bytes += bytes_count
         logging.debug('Downloaded %d bytes', total_bytes)
 

--- a/tests/dags/operators/test_http_to_s3_transfer.py
+++ b/tests/dags/operators/test_http_to_s3_transfer.py
@@ -1,4 +1,7 @@
-import unittest.mock as mock
+try:
+    import unittest.mock as mock
+except ImportError:
+    import mock
 import pytest
 from dags.operators.http_to_s3_transfer import HTTPToS3Transfer
 

--- a/tests/dags/utils/test_helpers.py
+++ b/tests/dags/utils/test_helpers.py
@@ -1,4 +1,7 @@
-import unittest.mock as mock
+try:
+    import unittest.mock as mock
+except ImportError:
+    import mock
 import dags.utils.helpers as helpers
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py35
+    py27
     lint
 skipsdist = True
 
@@ -8,6 +8,7 @@ skipsdist = True
 deps =
     -r{toxinidir}/requirements.txt
     pytest
+    mock
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/dags
     AIRFLOW_DAGS = {toxinidir}/dags


### PR DESCRIPTION
The Docker image uses Python 2.7, and we have found a few Airflow bugs on 3.5,
so the hassle of using 3.5 doesn't seem worth it now.