### PR TITLE
[#488] Create DAG that dumps our API DB to S3 monthly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,8 @@ MAINTAINER opentrials
 
 USER root
 RUN apt-get update -yqq && \
-    apt-get install -yqq python-pip
+    apt-get install -yqq python-pip && \
+    apt-get install -yqq postgresql-client
 
 ADD requirements.txt /
 RUN pip install -r /requirements.txt

--- a/dags/data_dumps.py
+++ b/dags/data_dumps.py
@@ -1,0 +1,62 @@
+import datetime
+import airflow
+from airflow.models import DAG
+from operators.postgres_to_s3_transfer import PostgresToS3Transfer
+
+args = {
+    'owner': 'airflow',
+    'depends_on_past': False,
+    'start_date': datetime.datetime(2017, 3, 15),
+    'retries': 1,
+    'retry_delay': datetime.timedelta(minutes=10),
+}
+
+dag = DAG(
+    dag_id='data_dumps',
+    default_args=args,
+    max_active_runs=1,
+    schedule_interval='@monthly'
+)
+
+tables_to_dump = [
+    'conditions',
+    'document_categories',
+    'documents',
+    'fda_applications',
+    'fda_approvals',
+    'files',
+    'interventions',
+    'knex_migrations',
+    'knex_migrations_id_seq',
+    'knex_migrations_lock',
+    'locations',
+    'organisations',
+    'persons',
+    'publications',
+    'records',
+    'risk_of_bias_criterias',
+    'risk_of_biases',
+    'risk_of_biases_risk_of_bias_criterias',
+    'sources',
+    'trials',
+    'trials_conditions',
+    'trials_documents',
+    'trials_interventions',
+    'trials_locations',
+    'trials_organisations',
+    'trials_persons',
+    'trials_publications',
+]
+datastore_http = airflow.hooks.BaseHook.get_connection('datastore_http')
+DUMP_API_URL = '{base}{endpoint}'.format(
+    base=datastore_http.host.replace('http://', 's3://'),
+    endpoint='/dumps/opentrials-api-{{ end_date }}.dump'
+)
+dump_api_database = PostgresToS3Transfer(
+    task_id='dump_api_database',
+    dag=dag,
+    postgres_conn_id='api_db',
+    tables=tables_to_dump,
+    s3_conn_id='datastore_s3',
+    s3_url=DUMP_API_URL
+)

--- a/dags/operators/postgres_to_s3_transfer.py
+++ b/dags/operators/postgres_to_s3_transfer.py
@@ -1,0 +1,90 @@
+from urllib.parse import urlparse
+import subprocess
+import logging
+import boto3
+
+import airflow.hooks
+from airflow.models import BaseOperator
+from airflow.utils.decorators import apply_defaults
+import utils.helpers as helpers
+
+
+class PostgresToS3Transfer(BaseOperator):
+    '''Dumps a Postgres database to a S3 key
+
+    :param url: URL to download. (templated)
+    :type url: str
+    :param postgres_conn_id: Postgres Connection's ID.
+    :type postgres_conn_id: str
+    :param tables: List of tables to export (optional, default exports all
+        tables).
+    :type tables: list of str
+    :param s3_conn_id: S3 Connection's ID. It needs a JSON in the `extra` field
+        with `aws_access_key_id` and `aws_secret_access_key`
+    :type s3_conn_id: str
+    :param s3_url: S3 url (e.g. `s3://my_bucket/my_key.zip`) (templated)
+    :type s3_url: str
+    '''
+    template_fields = ('s3_url',)
+
+    @apply_defaults
+    def __init__(self, postgres_conn_id, s3_conn_id, s3_url, tables=None, *args, **kwargs):
+        super(PostgresToS3Transfer, self).__init__(*args, **kwargs)
+        self.postgres_conn_id = postgres_conn_id
+        self.tables = tables
+        self.s3_conn_id = s3_conn_id
+        self.s3_url = s3_url
+
+    def execute(self, context):
+        s3 = self._load_s3_connection(self.s3_conn_id)
+        s3_bucket, s3_key = self._parse_s3_url(self.s3_url)
+        command = [
+            'pg_dump',
+            '-Fc',
+        ]
+
+        if self.tables:
+            tables_params = ['--table={}'.format(table) for table in self.tables]
+            command.extend(tables_params)
+
+        logging.info('Dumping database "%s" into "%s"', self.postgres_conn_id, self.s3_url)
+        logging.info('Command: %s <POSTGRES_URI>', ' '.join(command))
+
+        command.append(helpers.get_postgres_uri(self.postgres_conn_id))
+
+        with subprocess.Popen(command, stdout=subprocess.PIPE).stdout as dump_file:
+            s3.Bucket(s3_bucket) \
+              .upload_fileobj(dump_file, s3_key)
+
+    @staticmethod
+    def _parse_s3_url(s3_url):
+        parsed_url = urlparse(s3_url)
+        if not parsed_url.netloc:
+            raise airflow.exceptions.AirflowException('Please provide a bucket_name')
+        else:
+            bucket_name = parsed_url.netloc
+            key = parsed_url.path.strip('/')
+            return (bucket_name, key)
+
+    def _load_s3_connection(self, conn_id):
+        '''
+        Parses the S3 connection and returns a Boto3 resource.
+
+        This should be implementing using the S3Hook, but it currently uses
+        boto (not boto3) which doesn't allow streaming.
+
+        :return: Boto3 resource
+        :rtype: boto3.resources.factory.s3.ServiceResource
+        '''
+        conn = airflow.hooks.BaseHook.get_connection(conn_id)
+        extra_dejson = conn.extra_dejson
+        key_id = extra_dejson['aws_access_key_id']
+        access_key = extra_dejson['aws_secret_access_key']
+
+        s3 = boto3.resource(
+            's3',
+            aws_access_key_id=key_id,
+            aws_secret_access_key=access_key
+        )
+
+        return s3

--- a/tests/dags/operators/test_postgres_to_s3_transfer.py
+++ b/tests/dags/operators/test_postgres_to_s3_transfer.py
@@ -1,0 +1,83 @@
+try:
+    import unittest.mock as mock
+except ImportError:
+    import mock
+import subprocess
+import dags.utils.helpers as helpers
+from dags.operators.postgres_to_s3_transfer import PostgresToS3Transfer
+
+
+class TestPostgresToS3Transfer(object):
+    def test_its_created_successfully(self):
+        operator = PostgresToS3Transfer(
+            task_id='task_id',
+            postgres_conn_id='postgres_conn_id',
+            s3_conn_id='s3_conn_id',
+            s3_url='s3://bucket/key'
+        )
+        assert operator
+
+    @mock.patch('subprocess.Popen')
+    @mock.patch('boto3.resource', autospec=True)
+    @mock.patch('airflow.hooks.BaseHook.get_connection')
+    def test_execute_streams_url_data_to_s3(self, get_connection_mock, boto3_mock, popen_mock):
+        operator = PostgresToS3Transfer(
+            task_id='task_id',
+            postgres_conn_id='postgres_conn_id',
+            s3_conn_id='s3_conn_id',
+            s3_url='s3://bucket/key'
+        )
+
+        operator.execute(None)
+
+        boto3_mock().Bucket.assert_called_with('bucket')
+        boto3_mock().Bucket().upload_fileobj.assert_called_with(
+            popen_mock().stdout.__enter__(),  # Needs __enter__() because it's called in a context manager
+            'key'
+        )
+
+    @mock.patch('subprocess.Popen')
+    @mock.patch('boto3.resource', autospec=True)
+    @mock.patch('airflow.hooks.BaseHook.get_connection')
+    def test_execute_calls_pg_dump_correctly(self, get_connection_mock, boto3_mock, popen_mock):
+        operator = PostgresToS3Transfer(
+            task_id='task_id',
+            postgres_conn_id='postgres_conn_id',
+            s3_conn_id='s3_conn_id',
+            s3_url='s3://bucket/key'
+        )
+
+        operator.execute(None)
+
+        expected_command = [
+            'pg_dump',
+            '-Fc',
+            helpers.get_postgres_uri(operator.postgres_conn_id),
+        ]
+        popen_mock.assert_called_with(expected_command, stdout=subprocess.PIPE)
+
+    @mock.patch('subprocess.Popen')
+    @mock.patch('boto3.resource', autospec=True)
+    @mock.patch('airflow.hooks.BaseHook.get_connection')
+    def test_execute_dumps_only_whitelisted_tables(self, get_connection_mock, boto3_mock, popen_mock):
+        tables = [
+            'users',
+            'log',
+        ]
+        operator = PostgresToS3Transfer(
+            task_id='task_id',
+            postgres_conn_id='postgres_conn_id',
+            tables=tables,
+            s3_conn_id='s3_conn_id',
+            s3_url='s3://bucket/key'
+        )
+
+        operator.execute(None)
+
+        popen_command = popen_mock.call_args[0][0]
+
+        # Ignore executable and the Postgres URI, as the params need to be
+        # between these two
+        pg_dump_params_without_uri = popen_command[1:-1]
+        for table in tables:
+            assert '--table={}'.format(table) in pg_dump_params_without_uri


### PR DESCRIPTION
The DAG whitelists which tables to dump, so we don't dump private data by
mistake. It uses the `pg_dump` software, which means the worker needs to have
`pg_dump` installed and compatible with the version of the Postgres instance
it's dumping (i.e. equal or superior version).

Fixes opentrials/opentrials#488