### PR TITLE
[#714] Avoid running previously-scheduled DAGs if there's a later scheduled run

### DIFF
--- a/dags/actrn.py
+++ b/dags/actrn.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from airflow.models import DAG
+from airflow.operators.latest_only_operator import LatestOnlyOperator
 import utils.helpers as helpers
 
 args = {
@@ -14,6 +15,11 @@ dag = DAG(
     default_args=args,
     max_active_runs=1,
     schedule_interval='@monthly'
+)
+
+latest_only_task = LatestOnlyOperator(
+    task_id='latest_only',
+    dag=dag,
 )
 
 collector_task = helpers.create_collector_task(
@@ -32,5 +38,6 @@ merge_identifiers_and_reindex_task = helpers.create_trigger_subdag_task(
     dag=dag
 )
 
+collector_task.set_upstream(latest_only_task)
 processor_task.set_upstream(collector_task)
 merge_identifiers_and_reindex_task.set_upstream(processor_task)

--- a/dags/cochrane_reviews.py
+++ b/dags/cochrane_reviews.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 import airflow.models
+from airflow.operators.latest_only_operator import LatestOnlyOperator
 import utils.helpers as helpers
 
 args = {
@@ -16,6 +17,11 @@ dag = airflow.models.DAG(
     schedule_interval='@monthly'
 )
 
+latest_only_task = LatestOnlyOperator(
+    task_id='latest_only',
+    dag=dag,
+)
+
 collector_task = helpers.create_collector_task(
     name='cochrane_reviews',
     dag=dag,
@@ -29,4 +35,5 @@ processor_task = helpers.create_processor_task(
     dag=dag
 )
 
+collector_task.set_upstream(latest_only_task)
 processor_task.set_upstream(collector_task)

--- a/dags/data_contributions.py
+++ b/dags/data_contributions.py
@@ -1,5 +1,6 @@
 import datetime
 from airflow.models import DAG
+from airflow.operators.latest_only_operator import LatestOnlyOperator
 import utils.helpers as helpers
 
 args = {
@@ -17,7 +18,14 @@ dag = DAG(
     schedule_interval='@daily'
 )
 
+latest_only_task = LatestOnlyOperator(
+    task_id='latest_only',
+    dag=dag,
+)
+
 data_contributions_processor_task = helpers.create_processor_task(
     name='data_contributions',
     dag=dag
 )
+
+data_contributions_processor_task.set_upstream(latest_only_task)

--- a/dags/data_dumps.py
+++ b/dags/data_dumps.py
@@ -2,6 +2,7 @@ import datetime
 import airflow
 import airflow.hooks.base_hook
 from airflow.models import DAG
+from airflow.operators.latest_only_operator import LatestOnlyOperator
 from operators.postgres_to_s3_transfer import PostgresToS3Transfer
 
 args = {
@@ -17,6 +18,11 @@ dag = DAG(
     default_args=args,
     max_active_runs=1,
     schedule_interval='@monthly'
+)
+
+latest_only_task = LatestOnlyOperator(
+    task_id='latest_only',
+    dag=dag,
 )
 
 tables_to_dump = [
@@ -61,3 +67,5 @@ dump_api_database = PostgresToS3Transfer(
     s3_conn_id='datastore_s3',
     s3_url=DUMP_API_URL
 )
+
+dump_api_database.set_upstream(latest_only_task)

--- a/dags/euctr.py
+++ b/dags/euctr.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from airflow.models import DAG
+from airflow.operators.latest_only_operator import LatestOnlyOperator
 import utils.helpers as helpers
 
 args = {
@@ -14,6 +15,11 @@ dag = DAG(
     default_args=args,
     max_active_runs=1,
     schedule_interval='@monthly'
+)
+
+latest_only_task = LatestOnlyOperator(
+    task_id='latest_only',
+    dag=dag,
 )
 
 collector_task = helpers.create_collector_task(
@@ -32,5 +38,6 @@ merge_identifiers_and_reindex_task = helpers.create_trigger_subdag_task(
     dag=dag
 )
 
+collector_task.set_upstream(latest_only_task)
 processor_task.set_upstream(collector_task)
 merge_identifiers_and_reindex_task.set_upstream(processor_task)

--- a/dags/gsk.py
+++ b/dags/gsk.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from airflow.models import DAG
+from airflow.operators.latest_only_operator import LatestOnlyOperator
 import utils.helpers as helpers
 
 args = {
@@ -14,6 +15,11 @@ dag = DAG(
     default_args=args,
     max_active_runs=1,
     schedule_interval='@monthly'
+)
+
+latest_only_task = LatestOnlyOperator(
+    task_id='latest_only',
+    dag=dag,
 )
 
 collector_task = helpers.create_collector_task(
@@ -32,5 +38,6 @@ merge_identifiers_and_reindex_task = helpers.create_trigger_subdag_task(
     dag=dag
 )
 
+collector_task.set_upstream(latest_only_task)
 processor_task.set_upstream(collector_task)
 merge_identifiers_and_reindex_task.set_upstream(processor_task)

--- a/dags/hra.py
+++ b/dags/hra.py
@@ -1,5 +1,6 @@
 import datetime
 import airflow.models
+from airflow.operators.latest_only_operator import LatestOnlyOperator
 import utils.helpers as helpers
 from operators.python_sensor import PythonSensor
 
@@ -15,6 +16,11 @@ dag = airflow.models.DAG(
     default_args=args,
     max_active_runs=1,
     schedule_interval='@monthly'
+)
+
+latest_only_task = LatestOnlyOperator(
+    task_id='latest_only',
+    dag=dag,
 )
 
 
@@ -51,5 +57,6 @@ processor_task = helpers.create_processor_task(
     dag=dag
 )
 
+wait_for_hra_api_availability_sensor.set_upstream(latest_only_task)
 collector_task.set_upstream(wait_for_hra_api_availability_sensor)
 processor_task.set_upstream(collector_task)

--- a/dags/icdcm.py
+++ b/dags/icdcm.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from airflow.models import DAG
+from airflow.operators.latest_only_operator import LatestOnlyOperator
 import utils.helpers as helpers
 
 args = {
@@ -16,6 +17,11 @@ dag = DAG(
     schedule_interval='@monthly'
 )
 
+latest_only_task = LatestOnlyOperator(
+    task_id='latest_only',
+    dag=dag,
+)
+
 collector_task = helpers.create_collector_task(
     name='icdcm',
     dag=dag
@@ -26,4 +32,5 @@ processor_task = helpers.create_processor_task(
     dag=dag
 )
 
+collector_task.set_upstream(latest_only_task)
 processor_task.set_upstream(collector_task)

--- a/dags/icdpcs.py
+++ b/dags/icdpcs.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from airflow.models import DAG
+from airflow.operators.latest_only_operator import LatestOnlyOperator
 import utils.helpers as helpers
 
 args = {
@@ -16,6 +17,11 @@ dag = DAG(
     schedule_interval='@monthly'
 )
 
+latest_only_task = LatestOnlyOperator(
+    task_id='latest_only',
+    dag=dag,
+)
+
 collector_task = helpers.create_collector_task(
     name='icdpcs',
     dag=dag
@@ -26,4 +32,5 @@ processor_task = helpers.create_processor_task(
     dag=dag
 )
 
+collector_task.set_upstream(latest_only_task)
 processor_task.set_upstream(collector_task)

--- a/dags/ictrp.py
+++ b/dags/ictrp.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 import airflow.models
+from airflow.operators.latest_only_operator import LatestOnlyOperator
 import utils.helpers as helpers
 
 args = {
@@ -14,6 +15,11 @@ dag = airflow.models.DAG(
     default_args=args,
     max_active_runs=1,
     schedule_interval='@monthly'
+)
+
+latest_only_task = LatestOnlyOperator(
+    task_id='latest_only',
+    dag=dag,
 )
 
 collector_task = helpers.create_collector_task(
@@ -35,5 +41,6 @@ merge_identifiers_and_reindex_task = helpers.create_trigger_subdag_task(
     dag=dag
 )
 
+collector_task.set_upstream(latest_only_task)
 processor_task.set_upstream(collector_task)
 merge_identifiers_and_reindex_task.set_upstream(processor_task)

--- a/dags/isrctn.py
+++ b/dags/isrctn.py
@@ -1,5 +1,6 @@
 import datetime
 from airflow.models import DAG
+from airflow.operators.latest_only_operator import LatestOnlyOperator
 import utils.helpers as helpers
 
 args = {
@@ -14,6 +15,11 @@ dag = DAG(
     default_args=args,
     max_active_runs=1,
     schedule_interval='@monthly'
+)
+
+latest_only_task = LatestOnlyOperator(
+    task_id='latest_only',
+    dag=dag,
 )
 
 collector_task = helpers.create_collector_task(
@@ -32,5 +38,6 @@ merge_identifiers_and_reindex_task = helpers.create_trigger_subdag_task(
     dag=dag
 )
 
+collector_task.set_upstream(latest_only_task)
 processor_task.set_upstream(collector_task)
 merge_identifiers_and_reindex_task.set_upstream(processor_task)

--- a/dags/jprn.py
+++ b/dags/jprn.py
@@ -1,5 +1,6 @@
 import datetime
 from airflow.models import DAG
+from airflow.operators.latest_only_operator import LatestOnlyOperator
 import utils.helpers as helpers
 
 args = {
@@ -14,6 +15,11 @@ dag = DAG(
     default_args=args,
     max_active_runs=1,
     schedule_interval='@monthly'
+)
+
+latest_only_task = LatestOnlyOperator(
+    task_id='latest_only',
+    dag=dag,
 )
 
 collector_task = helpers.create_collector_task(
@@ -32,5 +38,6 @@ merge_identifiers_and_reindex_task = helpers.create_trigger_subdag_task(
     dag=dag
 )
 
+collector_task.set_upstream(latest_only_task)
 processor_task.set_upstream(collector_task)
 merge_identifiers_and_reindex_task.set_upstream(processor_task)

--- a/dags/pfizer.py
+++ b/dags/pfizer.py
@@ -1,5 +1,6 @@
 import datetime
 from airflow.models import DAG
+from airflow.operators.latest_only_operator import LatestOnlyOperator
 import utils.helpers as helpers
 
 args = {
@@ -16,6 +17,11 @@ dag = DAG(
     schedule_interval='@monthly'
 )
 
+latest_only_task = LatestOnlyOperator(
+    task_id='latest_only',
+    dag=dag,
+)
+
 collector_task = helpers.create_collector_task(
     name='pfizer_collector',
     dag=dag
@@ -26,4 +32,5 @@ processor_task = helpers.create_processor_task(
     dag=dag
 )
 
+collector_task.set_upstream(latest_only_task)
 processor_task.set_upstream(collector_task)

--- a/dags/pubmed.py
+++ b/dags/pubmed.py
@@ -1,5 +1,6 @@
 import datetime
 from airflow.models import DAG
+from airflow.operators.latest_only_operator import LatestOnlyOperator
 import utils.helpers as helpers
 
 args = {
@@ -14,6 +15,11 @@ dag = DAG(
     default_args=args,
     max_active_runs=1,
     schedule_interval='@monthly'
+)
+
+latest_only_task = LatestOnlyOperator(
+    task_id='latest_only',
+    dag=dag,
 )
 
 collector_task = helpers.create_collector_task(
@@ -42,6 +48,7 @@ merge_identifiers_and_reindex_task = helpers.create_trigger_subdag_task(
     dag=dag
 )
 
+collector_task.set_upstream(latest_only_task)
 unregistered_trials_task.set_upstream(collector_task)
 trials_remover_task.set_upstream(unregistered_trials_task)
 pubmed_publications_task.set_upstream(trials_remover_task)

--- a/dags/takeda.py
+++ b/dags/takeda.py
@@ -1,5 +1,6 @@
 import datetime
 from airflow.models import DAG
+from airflow.operators.latest_only_operator import LatestOnlyOperator
 import utils.helpers as helpers
 
 args = {
@@ -14,6 +15,11 @@ dag = DAG(
     default_args=args,
     max_active_runs=1,
     schedule_interval='@monthly'
+)
+
+latest_only_task = LatestOnlyOperator(
+    task_id='latest_only',
+    dag=dag,
 )
 
 collector_task = helpers.create_collector_task(
@@ -31,5 +37,6 @@ merge_identifiers_and_reindex_task = helpers.create_trigger_subdag_task(
     dag=dag
 )
 
+collector_task.set_upstream(latest_only_task)
 processor_task.set_upstream(collector_task)
 merge_identifiers_and_reindex_task.set_upstream(processor_task)


### PR DESCRIPTION
Most of our scrapers extract **all** data from the sources, so if we already
scheduled the DAG to run (say) today, it makes no sense to waste time running
previously-scheduled DAG runs. We just need to run the latest schedule.

Fixes opentrials/opentrials#714