### PR TITLE
[#812] Use LocalExecutor instead of CeleryExecutor

### DIFF
--- a/ansible/deploy_dockercloud.yml
+++ b/ansible/deploy_dockercloud.yml
@@ -15,13 +15,14 @@
     - name: update Docker Cloud stack
       shell: docker-cloud stack update --sync $DOCKERCLOUD_STACK -f {{ dockercloud_conf }}
       environment:
+        EXECUTOR: Local
+        AIRFLOW_ENABLE_AUTH: True
         REMOTE_BASE_LOG_FOLDER: "{{ remote_base_log_folder }}"
         REMOTE_LOG_CONN_ID: "{{ remote_log_conn_id }}"
         DB_URI: "{{ db_uri }}"
         DB_USER: "{{ db_user }}"
         DB_PASSWORD: "{{ db_password }}"
         DB_TABLE: "{{ db_table }}"
-        AIRFLOW_ENABLE_AUTH: True
         SMTP_HOST: "{{ smtp_host }}"
         SMTP_USER: "{{ smtp_user }}"
         SMTP_PASSWORD: "{{ smtp_password }}"

--- a/ansible/deploy_local.yml
+++ b/ansible/deploy_local.yml
@@ -13,6 +13,7 @@
         - docker-compose -f {{ compose_conf[0] }} -f {{ compose_conf[1] }} down -v --remove-orphans
         - docker-compose -f {{ compose_conf[0] }} -f {{ compose_conf[1] }} up -d
       environment:
+        EXECUTOR: Local
         AIRFLOW_ENABLE_AUTH: False
         FERNET_KEY: 46BKJoQYlPPOexq0OhDZnIlNepKFf87WFwLbfzqDDho=
         REMOTE_BASE_LOG_FOLDER: "{{ remote_base_log_folder }}"

--- a/ansible/files/docker-cloud.yml
+++ b/ansible/files/docker-cloud.yml
@@ -1,12 +1,8 @@
-redis:
-  image: 'redis:3.2.7'
-  restart: always
-
 webserver:
   image: 'opentrials/opentrials-airflow:latest'
   restart: always
   environment:
-    - EXECUTOR=Celery
+    - EXECUTOR
     - AIRFLOW_ENABLE_AUTH
     - REMOTE_BASE_LOG_FOLDER
     - REMOTE_LOG_CONN_ID
@@ -20,37 +16,13 @@ webserver:
     - SMTP_PASSWORD
   ports:
     - '80:8080'
-  links:
-    - redis
   command: webserver
-
-flower:
-  image: 'opentrials/opentrials-airflow:latest'
-  restart: always
-  environment:
-    - EXECUTOR=Celery
-    - AIRFLOW_ENABLE_AUTH
-    - REMOTE_BASE_LOG_FOLDER
-    - REMOTE_LOG_CONN_ID
-    - FERNET_KEY
-    - DB_URI
-    - DB_USER
-    - DB_PASSWORD
-    - DB_TABLE
-    - SMTP_HOST
-    - SMTP_USER
-    - SMTP_PASSWORD
-  links:
-    - redis
-  ports:
-    - '5555:5555'
-  command: flower
 
 scheduler:
   image: 'opentrials/opentrials-airflow:latest'
   restart: always
   environment:
-    - EXECUTOR=Celery
+    - EXECUTOR
     - AIRFLOW_ENABLE_AUTH
     - REMOTE_BASE_LOG_FOLDER
     - REMOTE_LOG_CONN_ID
@@ -62,30 +34,4 @@ scheduler:
     - SMTP_HOST
     - SMTP_USER
     - SMTP_PASSWORD
-  links:
-    - redis
   command: scheduler
-
-worker:
-  image: 'opentrials/opentrials-airflow:latest'
-  restart: always
-  ports:
-    - '8793:8793'
-  volumes:
-    - '/var/run/docker.sock:/var/run/docker.sock'
-  environment:
-    - EXECUTOR=Celery
-    - AIRFLOW_ENABLE_AUTH
-    - REMOTE_BASE_LOG_FOLDER
-    - REMOTE_LOG_CONN_ID
-    - FERNET_KEY
-    - DB_URI
-    - DB_USER
-    - DB_PASSWORD
-    - DB_TABLE
-    - SMTP_HOST
-    - SMTP_USER
-    - SMTP_PASSWORD
-  links:
-    - redis
-  command: worker

--- a/ansible/files/docker-compose-local.yml
+++ b/ansible/files/docker-compose-local.yml
@@ -19,11 +19,3 @@ services:
   scheduler:
       links:
           - postgres:postgres
-
-  worker:
-      links:
-          - postgres:postgres
-
-  flower:
-      links:
-          - postgres:postgres

--- a/ansible/files/docker-compose.yml
+++ b/ansible/files/docker-compose.yml
@@ -1,15 +1,10 @@
 version: '2'
 services:
-    redis:
-        image: 'redis:3.2.7'
-
     webserver:
         image: opentrials/opentrials-airflow
         restart: always
-        depends_on:
-            - redis
         environment:
-            EXECUTOR: Celery
+            EXECUTOR:
             AIRFLOW_ENABLE_AUTH:
             REMOTE_BASE_LOG_FOLDER:
             REMOTE_LOG_CONN_ID:
@@ -25,35 +20,15 @@ services:
             - "8080:8080"
         command: webserver
 
-    flower:
-        image: opentrials/opentrials-airflow
-        restart: always
-        depends_on:
-            - redis
-        environment:
-            EXECUTOR: Celery
-            AIRFLOW_ENABLE_AUTH:
-            REMOTE_BASE_LOG_FOLDER:
-            REMOTE_LOG_CONN_ID:
-            FERNET_KEY:
-            DB_URI:
-            DB_USER:
-            DB_PASSWORD:
-            DB_TABLE:
-            SMTP_HOST:
-            SMTP_USER:
-            SMTP_PASSWORD:
-        ports:
-            - "5555:5555"
-        command: flower
-
     scheduler:
         image: opentrials/opentrials-airflow
         restart: always
+        volumes:
+            - '/var/run/docker.sock:/var/run/docker.sock'
         depends_on:
             - webserver
         environment:
-            EXECUTOR: Celery
+            EXECUTOR:
             AIRFLOW_ENABLE_AUTH:
             REMOTE_BASE_LOG_FOLDER:
             REMOTE_LOG_CONN_ID:
@@ -66,25 +41,3 @@ services:
             SMTP_USER:
             SMTP_PASSWORD:
         command: ['scheduler', '--num_runs', '10']
-
-    worker:
-        image: opentrials/opentrials-airflow
-        restart: always
-        volumes:
-            - '/var/run/docker.sock:/var/run/docker.sock'
-        depends_on:
-            - scheduler
-        environment:
-            EXECUTOR: Celery
-            AIRFLOW_ENABLE_AUTH:
-            REMOTE_BASE_LOG_FOLDER:
-            REMOTE_LOG_CONN_ID:
-            FERNET_KEY:
-            DB_URI:
-            DB_USER:
-            DB_PASSWORD:
-            DB_TABLE:
-            SMTP_HOST:
-            SMTP_USER:
-            SMTP_PASSWORD:
-        command: worker


### PR DESCRIPTION
There's a bug with the CeleryExecutor and DockerOperator where long-running
tasks are stuck in a "running" state, even after the Docker container finished.
I reported the bug on https://issues.apache.org/jira/browse/AIRFLOW-1131.

While that's not finished, we use the LocalExecutor as a workaround.

Fixes opentrials/opentrials#812